### PR TITLE
Experimental: latency compensation - additional timeline for people who play with high ping

### DIFF
--- a/ActionTimelineReborn/ActionTimelineReborn.csproj
+++ b/ActionTimelineReborn/ActionTimelineReborn.csproj
@@ -5,7 +5,7 @@
 		<Authors>The Combat Reborn Team</Authors>
 		<PlatformTarget>x64</PlatformTarget>
 		<Platforms>AnyCPU</Platforms>
-		<Version>7.4.0.0</Version>
+		<Version>7.5.6.0</Version>
 		<Nullable>enable</Nullable>
 		<DalamudLibPath>$(AppData)\XIVLauncher\addon\Hooks\dev\</DalamudLibPath>
 		<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>

--- a/ActionTimelineReborn/Configurations/DrawingSettings.cs
+++ b/ActionTimelineReborn/Configurations/DrawingSettings.cs
@@ -79,6 +79,15 @@ public class DrawingSettings
     public Vector4 GridStartLineColor = new (0.3f, 0.5f, 0.2f, 1f);
     public Vector4 GridSubdivisionLineColor = new (0.3f, 0.3f, 0.3f, 0.2f);
 
+    /// <summary>
+    /// Experimental: draw this window on the press clock rather than the packet-arrival
+    /// clock. Requires <see cref="ExperimentalSettings.Enable"/>; ignored otherwise, so an
+    /// untouched window always renders exactly as it did before.
+    /// </summary>
+    public bool UseLatencyCompensationSetting = false;
+    public bool UseLatencyCompensation
+        => UseLatencyCompensationSetting && (Plugin.Settings?.Experimental?.Enable ?? false);
+
     public bool ShowGCDClippingSetting = true;
     public bool ShowGCDClipping => !IsRotation && ShowGCDClippingSetting;
     public float GCDClippingThreshold = 0.15f;

--- a/ActionTimelineReborn/Configurations/ExperimentalSettings.cs
+++ b/ActionTimelineReborn/Configurations/ExperimentalSettings.cs
@@ -1,0 +1,49 @@
+using System.Numerics;
+
+namespace ActionTimelineReborn.Configurations;
+
+/// <summary>
+/// Settings for the experimental latency-compensation feature.
+/// Everything here is additive: with <see cref="Enable"/> false the plugin behaves
+/// exactly as it did before this feature existed.
+/// </summary>
+[Serializable]
+public class ExperimentalSettings
+{
+    /// <summary>
+    /// Master switch. While false no request timestamps are captured at all and every
+    /// timeline draws from the original packet-arrival clock.
+    /// </summary>
+    public bool Enable = false;
+
+    /// <summary>
+    /// Measured request->response delays above this are treated as a bad match
+    /// (sequence reuse, a stall, a loading screen) and discarded.
+    /// </summary>
+    public int MaxDelayMs = 600;
+
+    /// <summary>
+    /// Exponential smoothing factor for the running delay average, matching the
+    /// approach BossMod uses for its own estimate. Higher = smoother/slower.
+    /// </summary>
+    public float DelaySmoothing = 0.8f;
+
+    /// <summary>
+    /// Use the smoothed average delay for effects that carry no source sequence
+    /// (DoT ticks, auto attacks, anything the server initiated).
+    /// </summary>
+    public bool FallbackToAverage = true;
+
+    /// <summary>
+    /// Draw the measured network delay for each action as its own thin band, so the
+    /// ping is still visible without being scored as a mistake.
+    /// </summary>
+    public bool ShowLatencyBand = false;
+
+    public Vector4 LatencyBandColor = new(0.35f, 0.65f, 1f, 0.55f);
+
+    /// <summary>
+    /// Show the live measured delay readout in the experimental settings tab.
+    /// </summary>
+    public bool ShowDebugReadout = true;
+}

--- a/ActionTimelineReborn/Configurations/ExperimentalSettings.cs
+++ b/ActionTimelineReborn/Configurations/ExperimentalSettings.cs
@@ -37,6 +37,19 @@ public class ExperimentalSettings
     public bool FallbackToAverage = true;
 
     /// <summary>
+    /// Shift a live compensated window's clock back by the average delay, so the newest
+    /// action still appears at the leading edge instead of popping in already displaced.
+    ///
+    /// Drawing on the press clock is truthful but feels laggy: we only learn an action
+    /// happened when its packet returns, by which point the press is already the delay in
+    /// the past, so the icon materialises away from the edge. What actually removes the
+    /// false gaps is exact spacing *between* actions, and a constant shift preserves that
+    /// completely. This trades absolute wall-clock alignment, which buys nothing, for the
+    /// responsive feel of the original.
+    /// </summary>
+    public bool AnchorLatestToEdge = true;
+
+    /// <summary>
     /// Draw the measured network delay for each action as its own thin band, so the
     /// ping is still visible without being scored as a mistake.
     /// </summary>

--- a/ActionTimelineReborn/Configurations/ExperimentalSettings.cs
+++ b/ActionTimelineReborn/Configurations/ExperimentalSettings.cs
@@ -19,8 +19,10 @@ public class ExperimentalSettings
     /// <summary>
     /// Measured request->response delays above this are treated as a bad match
     /// (sequence reuse, a stall, a loading screen) and discarded.
+    /// Raid latency spikes well past a nominal ping, so this has to sit comfortably
+    /// above the worst case or the spikiest actions are the ones that get thrown away.
     /// </summary>
-    public int MaxDelayMs = 600;
+    public int MaxDelayMs = 1200;
 
     /// <summary>
     /// Exponential smoothing factor for the running delay average, matching the

--- a/ActionTimelineReborn/Configurations/Settings.cs
+++ b/ActionTimelineReborn/Configurations/Settings.cs
@@ -18,6 +18,13 @@ public class Settings : IPluginConfiguration
     public bool PrintClipping = false;
     public int PrintClippingMin = 150;
     public int PrintClippingMax = 2000;
+
+    /// <summary>
+    /// Experimental latency compensation. Additive and off by default; see
+    /// <see cref="ExperimentalSettings"/>.
+    /// </summary>
+    public ExperimentalSettings Experimental { get; set; } = new();
+
     public int Version { get; set; } = 6;
 
     public void Save()

--- a/ActionTimelineReborn/Experimental/LatencyTracker.cs
+++ b/ActionTimelineReborn/Experimental/LatencyTracker.cs
@@ -1,0 +1,227 @@
+using ECommons.DalamudServices;
+using ECommons.GameHelpers;
+using FFXIVClientStructs.FFXIV.Client.Game;
+
+namespace ActionTimelineReborn.Experimental;
+
+/// <summary>
+/// Captures the moment an action request leaves this client, so the timeline can be drawn
+/// on the press clock instead of the packet-arrival clock.
+///
+/// Why this matters: every timestamp the plugin normally records is DateTime.Now inside a
+/// server packet handler, i.e. press + network delay. BossMod's animation lock tweak, by
+/// contrast, re-anchors the real animation lock to the press. The two clocks disagree by
+/// the round trip, so with a high ping the drawn timeline lags what actually happened.
+///
+/// Rather than hooking ActionManager.UseActionLocation (which would mean a second detour on
+/// a function BossMod already hooks, and a delegate signature that has to stay correct
+/// across patches), this watches ActionManager.LastUsedActionSequence from the framework
+/// tick. The sequence increments when the client sends the request, so a change means
+/// "a request just went out". Accuracy is one frame, which is far below the delays this is
+/// correcting, and nothing is hooked or written to.
+/// </summary>
+public sealed class LatencyTracker : IDisposable
+{
+    public static LatencyTracker? Instance { get; private set; }
+
+    public static void Initialize()
+    {
+        Instance ??= new LatencyTracker();
+    }
+
+    private const int RingSize = 16;
+
+    private readonly ushort[] _seq = new ushort[RingSize];
+    private readonly DateTime[] _time = new DateTime[RingSize];
+    private int _head;
+
+    private ushort _lastSeenSequence;
+    private bool _primed;
+    private bool _wasEnabled;
+
+    /// <summary>Smoothed request-&gt;response delay in seconds.</summary>
+    public float AverageDelay { get; private set; }
+
+    /// <summary>Most recent matched delay in seconds.</summary>
+    public float LastDelay { get; private set; }
+
+    /// <summary>How many effects have been matched to a request since the feature was enabled.</summary>
+    public int MatchedCount { get; private set; }
+
+    /// <summary>How many effects fell back to the average (no usable source sequence).</summary>
+    public int FallbackCount { get; private set; }
+
+    private LatencyTracker()
+    {
+        Svc.Framework.Update += OnFrameworkUpdate;
+    }
+
+    public void Dispose()
+    {
+        Svc.Framework.Update -= OnFrameworkUpdate;
+        Instance = null;
+    }
+
+    private static ExperimentalSettingsView Config => new(Plugin.Settings?.Experimental);
+
+    /// <summary>
+    /// Small read-only view so this class degrades safely if settings are not loaded yet.
+    /// </summary>
+    private readonly struct ExperimentalSettingsView(Configurations.ExperimentalSettings? s)
+    {
+        public bool Enable => s?.Enable ?? false;
+        public float MaxDelay => (s?.MaxDelayMs ?? 600) / 1000f;
+        public float Smoothing => Math.Clamp(s?.DelaySmoothing ?? 0.8f, 0f, 0.99f);
+        public bool FallbackToAverage => s?.FallbackToAverage ?? true;
+    }
+
+    private unsafe void OnFrameworkUpdate(Dalamud.Plugin.Services.IFramework framework)
+    {
+        var enabled = Config.Enable;
+
+        if (!enabled)
+        {
+            // Drop everything the moment the feature is switched off, so re-enabling later
+            // cannot match an effect against a stale request from minutes ago.
+            if (_wasEnabled) Reset();
+            _wasEnabled = false;
+            return;
+        }
+
+        _wasEnabled = true;
+
+        if (!Player.Available)
+        {
+            _primed = false;
+            return;
+        }
+
+        try
+        {
+            var manager = ActionManager.Instance();
+            if (manager == null) return;
+
+            var seq = manager->LastUsedActionSequence;
+
+            if (!_primed)
+            {
+                // First tick after login/zone: adopt the current value without recording it,
+                // otherwise we would stamp an old request with the current time.
+                _lastSeenSequence = seq;
+                _primed = true;
+                return;
+            }
+
+            if (seq == _lastSeenSequence) return;
+
+            _lastSeenSequence = seq;
+            _seq[_head] = seq;
+            _time[_head] = DateTime.Now;
+            _head = (_head + 1) % RingSize;
+        }
+        catch (Exception ex)
+        {
+            Svc.Log.Warning(ex, "[ATR] LatencyTracker update failed");
+        }
+    }
+
+    private void Reset()
+    {
+        Array.Clear(_seq);
+        Array.Clear(_time);
+        _head = 0;
+        _primed = false;
+        AverageDelay = 0;
+        LastDelay = 0;
+        MatchedCount = 0;
+        FallbackCount = 0;
+    }
+
+    /// <summary>
+    /// Resolve the press time for an effect that arrived at <paramref name="arrival"/>.
+    /// Returns false if no usable estimate exists, in which case the caller must keep
+    /// using the arrival time.
+    /// </summary>
+    public bool TryResolve(ushort sourceSequence, DateTime arrival, out DateTime requestTime, out float delaySeconds)
+    {
+        requestTime = arrival;
+        delaySeconds = 0;
+
+        var cfg = Config;
+        if (!cfg.Enable) return false;
+
+        if (sourceSequence != 0)
+        {
+            // Take the newest plausible entry, not the first in array order: the sequence
+            // restarts on zone change and relog, so the ring can legitimately hold two
+            // entries with the same number minutes apart.
+            var best = default(DateTime);
+            for (var i = 0; i < RingSize; i++)
+            {
+                if (_seq[i] != sourceSequence) continue;
+                if (_time[i] == default) continue;
+
+                var candidate = (arrival - _time[i]).TotalSeconds;
+                if (candidate < 0 || candidate > cfg.MaxDelay) continue;
+                if (_time[i] > best) best = _time[i];
+            }
+
+            if (best != default)
+            {
+                requestTime = best;
+                delaySeconds = (float)(arrival - best).TotalSeconds;
+
+                AverageDelay = MatchedCount == 0
+                    ? delaySeconds
+                    : delaySeconds * (1 - cfg.Smoothing) + AverageDelay * cfg.Smoothing;
+                LastDelay = delaySeconds;
+                MatchedCount++;
+                return true;
+            }
+        }
+
+        // Server-initiated effects (DoT ticks, auto attacks) carry no source sequence.
+        if (!cfg.FallbackToAverage || MatchedCount == 0) return false;
+
+        delaySeconds = AverageDelay;
+        requestTime = arrival - TimeSpan.FromSeconds(AverageDelay);
+        FallbackCount++;
+        return true;
+    }
+
+    /// <summary>
+    /// Resolve by recency rather than sequence, for the cast-start packet which carries no
+    /// sequence of its own. Takes the newest request that is not implausibly old.
+    /// </summary>
+    public bool TryResolveByRecency(DateTime arrival, out DateTime requestTime, out float delaySeconds)
+    {
+        requestTime = arrival;
+        delaySeconds = 0;
+
+        var cfg = Config;
+        if (!cfg.Enable) return false;
+
+        var best = default(DateTime);
+        for (var i = 0; i < RingSize; i++)
+        {
+            if (_time[i] == default) continue;
+            var delay = (arrival - _time[i]).TotalSeconds;
+            if (delay < 0 || delay > cfg.MaxDelay) continue;
+            if (_time[i] > best) best = _time[i];
+        }
+
+        if (best != default)
+        {
+            requestTime = best;
+            delaySeconds = (float)(arrival - best).TotalSeconds;
+            return true;
+        }
+
+        if (!cfg.FallbackToAverage || MatchedCount == 0) return false;
+
+        delaySeconds = AverageDelay;
+        requestTime = arrival - TimeSpan.FromSeconds(AverageDelay);
+        FallbackCount++;
+        return true;
+    }
+}

--- a/ActionTimelineReborn/Experimental/LatencyTracker.cs
+++ b/ActionTimelineReborn/Experimental/LatencyTracker.cs
@@ -42,6 +42,23 @@ public sealed class LatencyTracker : IDisposable
     /// <summary>Smoothed request-&gt;response delay in seconds.</summary>
     public float AverageDelay { get; private set; }
 
+    /// <summary>
+    /// The offset a live compensated window should shift its clock by, glided toward
+    /// <see cref="AverageDelay"/> a little each frame.
+    ///
+    /// Using the average directly makes the whole window lurch sideways whenever it
+    /// updates: it only changes when an action resolves, so a delay spike moves every icon
+    /// on screen by several pixels in a single frame. The average has to stay responsive
+    /// because it also places effects that carry no request of their own, so this is a
+    /// separate value that only ever moves smoothly.
+    /// </summary>
+    public float AnchorOffset { get; private set; }
+
+    /// <summary>Seconds for the anchor to close ~63% of the distance to the average.</summary>
+    private const float AnchorTimeConstant = 0.75f;
+
+    private bool _anchorPrimed;
+
     /// <summary>Most recent matched delay in seconds.</summary>
     public float LastDelay { get; private set; }
 
@@ -90,6 +107,8 @@ public sealed class LatencyTracker : IDisposable
 
         _wasEnabled = true;
 
+        UpdateAnchor(framework);
+
         if (!Player.Available)
         {
             _primed = false;
@@ -125,6 +144,30 @@ public sealed class LatencyTracker : IDisposable
         }
     }
 
+    private void UpdateAnchor(Dalamud.Plugin.Services.IFramework framework)
+    {
+        if (MatchedCount == 0) return;
+
+        // Snap on the first measurement, otherwise the window would visibly slide into
+        // place over the first second after the feature is switched on.
+        if (!_anchorPrimed)
+        {
+            AnchorOffset = AverageDelay;
+            _anchorPrimed = true;
+            return;
+        }
+
+        var dt = (float)framework.UpdateDelta.TotalSeconds;
+
+        // Ignore a stalled or paused frame rather than lurching the whole window at once.
+        if (dt <= 0f || dt > 1f) return;
+
+        // Time-constant based rather than a flat per-frame fraction, so the glide takes the
+        // same wall-clock time at 60fps and at 144fps.
+        var k = 1f - MathF.Exp(-dt / AnchorTimeConstant);
+        AnchorOffset += (AverageDelay - AnchorOffset) * k;
+    }
+
     private void Reset()
     {
         Array.Clear(_seq);
@@ -132,6 +175,8 @@ public sealed class LatencyTracker : IDisposable
         _head = 0;
         _primed = false;
         AverageDelay = 0;
+        AnchorOffset = 0;
+        _anchorPrimed = false;
         LastDelay = 0;
         MatchedCount = 0;
         FallbackCount = 0;

--- a/ActionTimelineReborn/Plugin.cs
+++ b/ActionTimelineReborn/Plugin.cs
@@ -1,4 +1,5 @@
 using ActionTimelineReborn.Configurations;
+using ActionTimelineReborn.Experimental;
 using ActionTimelineReborn.Helpers;
 using ActionTimelineReborn.Timeline;
 using ActionTimelineReborn.Windows;
@@ -89,6 +90,12 @@ public class Plugin : IDalamudPlugin
         {
             Settings = new Settings();
         }
+
+        // Configs written before the experimental feature existed deserialize this as null.
+        Settings.Experimental ??= new ExperimentalSettings();
+
+        // Must come after Settings, since the tracker reads its enable flag every tick.
+        LatencyTracker.Initialize();
 
         CreateWindows();
         _settingsWindow.TitleBarButtons.Add(new TitleBarButton()
@@ -216,6 +223,8 @@ public class Plugin : IDalamudPlugin
         if (!disposing) return;
 
         Settings.Save();
+
+        LatencyTracker.Instance?.Dispose();
 
         TimelineManager.Instance?.Dispose();
 

--- a/ActionTimelineReborn/Timeline/StatusLineItem.cs
+++ b/ActionTimelineReborn/Timeline/StatusLineItem.cs
@@ -15,6 +15,15 @@ public class StatusLineItem : ITimelineItem
 
     public DateTime EndTime => StartTime + TimeSpan.FromSeconds(TimeDuration);
 
+    /// <summary>
+    /// Press time of the action that applied this status, when the experimental latency
+    /// tracker resolved one. Keeps status bars aligned with their compensated action.
+    /// </summary>
+    public DateTime? RequestTime { get; set; }
+
+    public DateTime DisplayStartTime(DrawingSettings setting)
+        => setting.UseLatencyCompensation ? RequestTime ?? StartTime : StartTime;
+
     public byte Stack { get; set; }
 
     public void Draw(DateTime time, Vector2 windowPos, Vector2 windowSize, DrawingSettings setting)
@@ -23,7 +32,7 @@ public class StatusLineItem : ITimelineItem
             ? new Vector2(windowSize.X, windowSize.Y / 2 + setting.CenterOffset)
             : new Vector2(windowSize.X / 2 + setting.CenterOffset, windowSize.Y));
         rightCenter -= setting.TimeOffset * setting.TimeDirectionPerSecond;
-        DrawItemWithCenter(rightCenter - (float)(time - StartTime).TotalSeconds * setting.TimeDirectionPerSecond, windowPos, setting);
+        DrawItemWithCenter(rightCenter - (float)(time - DisplayStartTime(setting)).TotalSeconds * setting.TimeDirectionPerSecond, windowPos, setting);
     }
 
     public void DrawItemWithCenter(Vector2 centerPos, Vector2 windowPos, DrawingSettings setting)

--- a/ActionTimelineReborn/Timeline/TimelineItem.cs
+++ b/ActionTimelineReborn/Timeline/TimelineItem.cs
@@ -205,16 +205,22 @@ public class TimelineItem : ITimelineItem
                      MinX(leftBottom + unitPerSecond * GCDTime, min),
                     GcdForeColor, rounding, flag, setting.GCDThickness);
 
-                //Network delay (experimental) - how long this action spent in flight.
+                //Network delay (experimental) - how long this action spent in flight, drawn
+                //from the press to the moment the packet came back.
                 //Only ever drawn on a window that opted into latency compensation.
                 var experimental = Plugin.Settings?.Experimental;
                 if (setting.UseLatencyCompensation && experimental is { ShowLatencyBand: true } && NetworkDelay > 0)
                 {
+                    //Deliberately not clamped to `min` like the bars above. A typical delay is
+                    //only a few pixels wide, so clamping it past the icon's edge erases it
+                    //entirely. Give it its own lane just clear of the icon instead.
                     var bandColor = ImGui.ColorConvertFloat4ToU32(experimental.LatencyBandColor);
-                    var bandThickness = iconSize * 0.08f;
-                    drawList.AddRectFilled(MinX(leftTop, min),
-                        MinX(leftTop + unitPerSecond * NetworkDelay + bandThickness * setting.RealDownDirection, min),
-                        bandColor, rounding, flag);
+                    var bandThickness = MathF.Max(3f, iconSize * 0.1f);
+                    var bandStart = centerPos + (iconSize / 2 + 1) * setting.DownDirection;
+                    var bandEnd = bandStart + unitPerSecond * NetworkDelay + bandThickness * setting.DownDirection;
+                    //Min/Max so this survives vertical timelines and the reversed direction,
+                    //where the corners would otherwise come out inverted and not draw.
+                    drawList.AddRectFilled(Vector2.Min(bandStart, bandEnd), Vector2.Max(bandStart, bandEnd), bandColor);
                 }
 
                 //Damage

--- a/ActionTimelineReborn/Timeline/TimelineItem.cs
+++ b/ActionTimelineReborn/Timeline/TimelineItem.cs
@@ -31,6 +31,29 @@ public class TimelineItem : ITimelineItem
 
     public DateTime EndTime => StartTime + TimeSpan.FromSeconds(TimeDuration);
 
+    /// <summary>
+    /// When this action's request left the client, if the experimental latency tracker
+    /// resolved one. Null means we only ever knew the packet-arrival time.
+    /// </summary>
+    public DateTime? RequestTime { get; set; }
+
+    /// <summary>Measured request-&gt;response delay in seconds, 0 when unknown.</summary>
+    public float NetworkDelay { get; set; }
+
+    public DateTime CompensatedStartTime => RequestTime ?? StartTime;
+
+    public DateTime CompensatedEndTime => CompensatedStartTime + TimeSpan.FromSeconds(TimeDuration);
+
+    /// <summary>
+    /// The start time this particular window should draw from. Windows that have not opted
+    /// into latency compensation always get the untouched arrival time.
+    /// </summary>
+    public DateTime DisplayStartTime(DrawingSettings setting)
+        => setting.UseLatencyCompensation ? CompensatedStartTime : StartTime;
+
+    public DateTime DisplayEndTime(DrawingSettings setting)
+        => setting.UseLatencyCompensation ? CompensatedEndTime : EndTime;
+
     public HashSet<(uint icon, string? name)> StatusGainIcon { get; } = new(4);
     public HashSet<(uint icon, string? name)> StatusLoseIcon { get;  } = new(4);
 
@@ -39,8 +62,8 @@ public class TimelineItem : ITimelineItem
         var rightCenter = windowPos + (setting.IsHorizonal
             ? new Vector2(windowSize.X, windowSize.Y / 2 + setting.CenterOffset)
             : new Vector2(windowSize.X / 2 + setting.CenterOffset, windowSize.Y));
-        rightCenter -= setting.TimeOffset * setting.TimeDirectionPerSecond; 
-        DrawItemWithCenter(rightCenter - (float)(time - StartTime).TotalSeconds * setting.TimeDirectionPerSecond, icon, setting);
+        rightCenter -= setting.TimeOffset * setting.TimeDirectionPerSecond;
+        DrawItemWithCenter(rightCenter - (float)(time - DisplayStartTime(setting)).TotalSeconds * setting.TimeDirectionPerSecond, icon, setting);
     }
 
     public void DrawItemWithCenter(Vector2 centerPos, TimelineLayer icon, DrawingSettings setting)
@@ -181,6 +204,18 @@ public class TimelineItem : ITimelineItem
                 drawList.AddRect(MinX(leftTop, min),
                      MinX(leftBottom + unitPerSecond * GCDTime, min),
                     GcdForeColor, rounding, flag, setting.GCDThickness);
+
+                //Network delay (experimental) - how long this action spent in flight.
+                //Only ever drawn on a window that opted into latency compensation.
+                var experimental = Plugin.Settings?.Experimental;
+                if (setting.UseLatencyCompensation && experimental is { ShowLatencyBand: true } && NetworkDelay > 0)
+                {
+                    var bandColor = ImGui.ColorConvertFloat4ToU32(experimental.LatencyBandColor);
+                    var bandThickness = iconSize * 0.08f;
+                    drawList.AddRectFilled(MinX(leftTop, min),
+                        MinX(leftTop + unitPerSecond * NetworkDelay + bandThickness * setting.RealDownDirection, min),
+                        bandColor, rounding, flag);
+                }
 
                 //Damage
                 if (setting.ShowDamageType)

--- a/ActionTimelineReborn/Timeline/TimelineManager.cs
+++ b/ActionTimelineReborn/Timeline/TimelineManager.cs
@@ -1,3 +1,4 @@
+using ActionTimelineReborn.Experimental;
 using Dalamud.Game.ClientState.Objects.Types;
 using Dalamud.Hooking;
 using Dalamud.Utility.Signatures;
@@ -83,6 +84,7 @@ public class TimelineManager : IDisposable
         _lastItem = null;
         _lastTime = DateTime.MinValue;
         EndTime = DateTime.Now;
+        CompensatedEndTime = DateTime.Now;
     }
     #endregion
 
@@ -106,6 +108,13 @@ public class TimelineManager : IDisposable
     private static readonly Dictionary<uint, (string name, ushort icon, float castTime)> _itemCache = [];
 
     public DateTime EndTime { get; private set; } = DateTime.Now;
+
+    /// <summary>
+    /// Same as <see cref="EndTime"/> but on the press clock, for rotation-mode windows that
+    /// opted into latency compensation. Equal to <see cref="EndTime"/> while the
+    /// experimental feature is off.
+    /// </summary>
+    public DateTime CompensatedEndTime { get; private set; } = DateTime.Now;
     private static readonly int kMaxItemCount = 2048;
     private readonly Queue<TimelineItem> _items = new(kMaxItemCount);
     private TimelineItem? _lastItem = null;
@@ -123,8 +132,14 @@ public class TimelineManager : IDisposable
         {
             _lastItem = item;
             _lastTime = DateTime.Now;
-            UpdateEndTime(item.EndTime);
+            UpdateEndTime(item);
         }
+    }
+
+    private void UpdateEndTime(TimelineItem item)
+    {
+        UpdateEndTime(item.EndTime);
+        if (item.CompensatedEndTime > CompensatedEndTime) CompensatedEndTime = item.CompensatedEndTime;
     }
 
     private void UpdateEndTime(DateTime endTime)
@@ -132,19 +147,25 @@ public class TimelineManager : IDisposable
         if(endTime > EndTime) EndTime = endTime;
     }
 
-    public List<TimelineItem> GetItems(DateTime time, out DateTime lastEndTime)
+    /// <summary>
+    /// Collect the items visible after <paramref name="time"/>. <paramref name="compensated"/>
+    /// selects the press clock instead of the packet-arrival clock; the two are identical
+    /// unless the experimental latency feature resolved a request time for an item.
+    /// </summary>
+    public List<TimelineItem> GetItems(DateTime time, bool compensated, out DateTime lastEndTime)
     {
         var result = new List<TimelineItem>();
         lastEndTime = DateTime.Now;
         foreach (var item in _items)
         {
-            if (item.EndTime > time)
+            var itemEnd = compensated ? item.CompensatedEndTime : item.EndTime;
+            if (itemEnd > time)
             {
                 result.Add(item);
             }
             else if (item.Type == TimelineItemType.GCD)
             {
-                lastEndTime = item.EndTime;
+                lastEndTime = itemEnd;
             }
         }
         return result;
@@ -303,6 +324,17 @@ public class TimelineManager : IDisposable
         var now = DateTime.Now;
         var type = GetActionType(set.Header.ActionID, set.Header.ActionType);
 
+        // Experimental: recover the moment this action's request left the client. Returns
+        // false (leaving requestTime null) whenever the feature is off, so everything below
+        // falls back to the original packet-arrival behaviour.
+        DateTime? requestTime = null;
+        float networkDelay = 0;
+        if (LatencyTracker.Instance?.TryResolve(set.Header.SourceSequence, now, out var resolvedRequest, out var resolvedDelay) == true)
+        {
+            requestTime = resolvedRequest;
+            networkDelay = resolvedDelay;
+        }
+
         if (Plugin.Settings.PrintClipping && type == TimelineItemType.GCD)
         {
             // Replace LINQ with manual loop for better performance
@@ -317,7 +349,8 @@ public class TimelineManager : IDisposable
             
             if(lastGcd != null)
             {
-                var time = (int)(now - lastGcd.EndTime).TotalMilliseconds;
+                // Compensated times equal the raw ones while the experimental feature is off.
+                var time = (int)((requestTime ?? now) - lastGcd.CompensatedEndTime).TotalMilliseconds;
                 if(time >= Plugin.Settings.PrintClippingMin &&  time <= Plugin.Settings.PrintClippingMax)
                 {
                     Svc.Chat.Print($"Clipping: {time}ms ({lastGcd.Name} - {set.Name})");
@@ -339,6 +372,8 @@ public class TimelineManager : IDisposable
             AddItem(new TimelineItem()
             {
                 StartTime = now,
+                RequestTime = requestTime,
+                NetworkDelay = networkDelay,
                 AnimationLockTime = type == TimelineItemType.AutoAttack ? 0 : set.Header.AnimationLockTime,
                 GCDTime = type == TimelineItemType.GCD ? GCD : 0,
                 Type = type,
@@ -365,7 +400,7 @@ public class TimelineManager : IDisposable
 
         if (effectItem.Type is TimelineItemType.AutoAttack) return;
 
-        UpdateEndTime(effectItem.EndTime);
+        UpdateEndTime(effectItem);
 
         if (set.Header.TargetCount > 0)
         {
@@ -393,6 +428,7 @@ public class TimelineManager : IDisposable
                         TimeDuration = 6,
                         Stack = stack,
                         StartTime = effectItem.StartTime,
+                        RequestTime = effectItem.RequestTime,
                     };
                     list.Add(item);
                     AddItem(item);
@@ -488,12 +524,26 @@ public class TimelineManager : IDisposable
 
             var action = Svc.Data.GetExcelSheet<Action>()?.GetRow(actionId);
 
+            var castStart = DateTime.Now;
+
+            // The cast-start packet carries no source sequence of its own, so match the most
+            // recent outgoing request instead. No-op while the experimental feature is off.
+            DateTime? castRequestTime = null;
+            float castDelay = 0;
+            if (LatencyTracker.Instance?.TryResolveByRecency(castStart, out var resolvedCastRequest, out var resolvedCastDelay) == true)
+            {
+                castRequestTime = resolvedCastRequest;
+                castDelay = resolvedCastDelay;
+            }
+
             AddItem(new TimelineItem()
             {
                 Name =  action?.Name.ToString() ?? string.Empty,
                 Icon =  actionId == 4 ? (ushort)118 //Mount
                         : action?.Icon ?? 0,
-                StartTime = DateTime.Now,
+                StartTime = castStart,
+                RequestTime = castRequestTime,
+                NetworkDelay = castDelay,
                 GCDTime = GCD,
                 CastingTime = Player.Object.TotalCastTime - Player.Object.CurrentCastTime,
                 Type = TimelineItemType.GCD,

--- a/ActionTimelineReborn/Windows/SettingsWindow.cs
+++ b/ActionTimelineReborn/Windows/SettingsWindow.cs
@@ -65,12 +65,98 @@ namespace ActionTimelineReborn.Windows
                 Settings.TimelineSettings.Remove(removingSetting);
             }
 
+            if (ImGui.BeginTabItem("Experimental"))
+            {
+                DrawExperimentalSetting();
+                ImGui.EndTabItem();
+            }
+
             if (ImGui.BeginTabItem("Help"))
             {
                 DrawHelp();
                 ImGui.EndTabItem();
             }
             ImGui.EndTabBar();
+        }
+
+        private void DrawExperimentalSetting()
+        {
+            var experimental = Settings.Experimental;
+
+            ImGui.TextColored(ImGuiColors.DalamudOrange,
+                "EXPERIMENTAL - off by default. With this unchecked ActionTimelineReborn behaves exactly as it always has.");
+            ImGui.Separator();
+
+            ImGui.TextWrapped(
+                "Every time the plugin normally records comes from a server packet arriving, so it is your press " +
+                "plus your ping. BossMod's animation lock tweak re-anchors the real animation lock to the press, " +
+                "so with a high ping the drawn timeline lags what actually happened. This measures the delay per " +
+                "action and can redraw a timeline on the press clock instead.");
+
+            ImGui.NewLine();
+
+            ImGui.Checkbox("Enable latency compensation", ref experimental.Enable);
+            DrawHelper.SetTooltip("Master switch. While off no request timestamps are captured at all.");
+
+            if (!experimental.Enable) return;
+
+            ImGui.NewLine();
+
+            if (ImGui.Button("Add Compensated Timeline"))
+            {
+                Settings.TimelineSettings.Add(new DrawingSettings()
+                {
+                    Name = "Compensated",
+                    UseLatencyCompensationSetting = true,
+                });
+            }
+            DrawHelper.SetTooltip("Adds a second timeline window drawn on the press clock, so you can compare it " +
+                "against your existing one side by side. You can also tick the option per timeline in its General tab.");
+
+            ImGui.NewLine();
+
+            ImGui.SetNextItemWidth(120 * _scale);
+            ImGui.DragInt("Max Delay (ms)", ref experimental.MaxDelayMs, 1f, 100, 2000);
+            DrawHelper.SetTooltip("Measured delays above this are treated as a bad match and discarded in favour " +
+                "of the running average. Set this comfortably above your worst ping.");
+
+            ImGui.SetNextItemWidth(120 * _scale);
+            ImGui.DragFloat("Delay Smoothing", ref experimental.DelaySmoothing, 0.01f, 0f, 0.99f);
+            DrawHelper.SetTooltip("Smoothing for the running delay average. Higher is smoother and slower to react.");
+
+            ImGui.Checkbox("Average Fallback", ref experimental.FallbackToAverage);
+            DrawHelper.SetTooltip("Effects the server started on its own (damage over time ticks, auto attacks) " +
+                "carry no request of their own. Use the running average for those.");
+
+            ImGui.NewLine();
+
+            ImGui.Checkbox("Show Latency Band", ref experimental.ShowLatencyBand);
+            DrawHelper.SetTooltip("Draw the measured delay for each action as its own thin band, so the ping is " +
+                "still visible without being counted as a mistake.");
+            if (experimental.ShowLatencyBand)
+            {
+                ImGui.ColorEdit4("Latency Band Color", ref experimental.LatencyBandColor, ImGuiColorEditFlags.NoInputs);
+            }
+
+            ImGui.NewLine();
+            ImGui.Checkbox("Show Measurements", ref experimental.ShowDebugReadout);
+
+            if (!experimental.ShowDebugReadout) return;
+
+            var tracker = Experimental.LatencyTracker.Instance;
+            if (tracker == null)
+            {
+                ImGui.TextColored(ImGuiColors.DalamudRed, "Tracker not running.");
+                return;
+            }
+
+            ImGui.Separator();
+            ImGui.Text($"Measured delay   last {tracker.LastDelay * 1000f:F0} ms   average {tracker.AverageDelay * 1000f:F0} ms");
+            ImGui.Text($"Actions matched  {tracker.MatchedCount}   average fallback {tracker.FallbackCount}");
+            if (tracker.MatchedCount == 0)
+            {
+                ImGui.TextColored(ImGuiColors.DalamudYellow, "No actions measured yet - use an action in combat.");
+            }
         }
 
         private void DrawHelp() 
@@ -330,6 +416,16 @@ namespace ActionTimelineReborn.Windows
             ImGui.Checkbox("Is Rotation", ref settings.IsRotation);
             ImGui.Checkbox("Is Horizonal", ref settings.IsHorizonal);
             ImGui.Checkbox("Is Reverse", ref settings.IsReverse);
+
+            ImGui.NewLine();
+
+            ImGui.Checkbox("Latency Compensated (experimental)", ref settings.UseLatencyCompensationSetting);
+            DrawHelper.SetTooltip("Draw this window on the press clock instead of the packet-arrival clock. " +
+                "Has no effect unless latency compensation is enabled in the Experimental tab.");
+            if (settings.UseLatencyCompensationSetting && !(Plugin.Settings.Experimental?.Enable ?? false))
+            {
+                ImGui.TextColored(ImGuiColors.DalamudYellow, "Enable it in the Experimental tab first.");
+            }
 
             ImGui.NewLine();
 

--- a/ActionTimelineReborn/Windows/SettingsWindow.cs
+++ b/ActionTimelineReborn/Windows/SettingsWindow.cs
@@ -130,6 +130,16 @@ namespace ActionTimelineReborn.Windows
 
             ImGui.NewLine();
 
+            ImGui.Checkbox("Pin Newest To Leading Edge", ref experimental.AnchorLatestToEdge);
+            DrawHelper.SetTooltip("Shifts a live compensated window's clock back by the average delay so the " +
+                "newest action still appears at the leading edge.\n\n" +
+                "Without this the timeline is drawn on the true press clock, which is honest but feels laggy: " +
+                "the icon cannot be drawn until its packet returns, so it pops in already displaced.\n\n" +
+                "Spacing between actions stays exact either way, which is what removes the false red gaps. " +
+                "Only the absolute alignment to wall-clock now changes.");
+
+            ImGui.NewLine();
+
             ImGui.Checkbox("Show Latency Band", ref experimental.ShowLatencyBand);
             DrawHelper.SetTooltip("Draw the measured delay for each action as its own thin band, so the ping is " +
                 "still visible without being counted as a mistake.");

--- a/ActionTimelineReborn/Windows/TimelineWindow.cs
+++ b/ActionTimelineReborn/Windows/TimelineWindow.cs
@@ -73,7 +73,9 @@ internal static class TimelineWindow
             && (Plugin.Settings?.Experimental?.AnchorLatestToEdge ?? false)
             && Experimental.LatencyTracker.Instance is { MatchedCount: > 0 } tracker)
         {
-            liveNow -= TimeSpan.FromSeconds(tracker.AverageDelay);
+            // AnchorOffset, not AverageDelay: the average steps whenever an action resolves,
+            // which would jerk every icon on screen sideways at once.
+            liveNow -= TimeSpan.FromSeconds(tracker.AnchorOffset);
         }
 
         var now = setting.IsRotation ? (rotationEnd ?? liveNow - TimeSpan.FromSeconds(setting.TimeOffset)) : liveNow;

--- a/ActionTimelineReborn/Windows/TimelineWindow.cs
+++ b/ActionTimelineReborn/Windows/TimelineWindow.cs
@@ -62,7 +62,21 @@ internal static class TimelineWindow
             ? TimelineManager.Instance?.CompensatedEndTime
             : TimelineManager.Instance?.EndTime;
 
-        var now = setting.IsRotation ? (rotationEnd ?? DateTime.Now - TimeSpan.FromSeconds(setting.TimeOffset)) : DateTime.Now;
+        var liveNow = DateTime.Now;
+
+        // A live compensated window draws on the press clock, but we only learn a press
+        // happened when its packet returns. Without this the newest icon appears already
+        // displaced from the leading edge and reads as lag. Shifting the whole window's
+        // clock by the average delay restores the leading-edge pop-in while leaving the
+        // spacing between actions - the part that actually removes the false gaps - exact.
+        if (compensated && !setting.IsRotation
+            && (Plugin.Settings?.Experimental?.AnchorLatestToEdge ?? false)
+            && Experimental.LatencyTracker.Instance is { MatchedCount: > 0 } tracker)
+        {
+            liveNow -= TimeSpan.FromSeconds(tracker.AverageDelay);
+        }
+
+        var now = setting.IsRotation ? (rotationEnd ?? liveNow - TimeSpan.FromSeconds(setting.TimeOffset)) : liveNow;
 
         var endTime = now - TimeSpan.FromSeconds((setting.IsHorizonal ? size.X : size.Y )/ setting.SizePerSecond - setting.TimeOffset);
 

--- a/ActionTimelineReborn/Windows/TimelineWindow.cs
+++ b/ActionTimelineReborn/Windows/TimelineWindow.cs
@@ -56,12 +56,18 @@ internal static class TimelineWindow
         var pos = ImGui.GetWindowPos();
         var size = ImGui.GetWindowSize();
 
-        var now = setting.IsRotation ? (TimelineManager.Instance?.EndTime ?? DateTime.Now - TimeSpan.FromSeconds(setting.TimeOffset)) : DateTime.Now;
+        var compensated = setting.UseLatencyCompensation;
+
+        var rotationEnd = compensated
+            ? TimelineManager.Instance?.CompensatedEndTime
+            : TimelineManager.Instance?.EndTime;
+
+        var now = setting.IsRotation ? (rotationEnd ?? DateTime.Now - TimeSpan.FromSeconds(setting.TimeOffset)) : DateTime.Now;
 
         var endTime = now - TimeSpan.FromSeconds((setting.IsHorizonal ? size.X : size.Y )/ setting.SizePerSecond - setting.TimeOffset);
 
         var last = now;
-        var list = TimelineManager.Instance?.GetItems(endTime, out last);
+        var list = TimelineManager.Instance?.GetItems(endTime, compensated, out last);
 
         var timeDirWhole = setting.IsHorizonal ? size.X * Vector2.UnitX : size.Y * Vector2.UnitY;
         var downDirWhole = setting.IsHorizonal ? size.Y * Vector2.UnitY : size.X * Vector2.UnitX;
@@ -78,7 +84,7 @@ internal static class TimelineWindow
             {
                 if (item.Type != TimelineItemType.GCD) continue;
 
-                var start = item.StartTime;
+                var start = item.DisplayStartTime(setting);
                 var span = start - last;
 
                 if (last != DateTime.MinValue && span >= threshold && span < max)
@@ -95,7 +101,7 @@ internal static class TimelineWindow
                         $"{(int)span.TotalMilliseconds}ms");
                 }
 
-                last = item.EndTime;
+                last = item.DisplayEndTime(setting);
             }
         }
 


### PR DESCRIPTION
I'm currently playing from overseas on the NA server. My usual ping is now 200ms, and it can spike to 500ms occasionally. I use BMR's anti-lag and reduce frame tweaks, but currently ATR doesn't draw the tweaked timeline. So, people on a high-ping connection like me see the drawn timeline lag instead of a delay that the tweaks already mitigated.

This experimental additional timeline is OFF by default. It runs independently from the existing timeline. Compensated rotation presses are drawn after calculation. Tested on multiple raids on my 200ms ping gameplay. 

e.g. Measured on a 200ms connection: 185 GCDs in one clear, 3 remaining gaps, all three traceable to mechanics rather than latency.